### PR TITLE
Parcels

### DIFF
--- a/Python/utils/Makefile
+++ b/Python/utils/Makefile
@@ -44,10 +44,4 @@ dedalus:
 
 # make parcels ENV=<env_name>
 parcels:
-	conda activate root
 	yes | conda create -n $$ENV -c conda-forge python=3.6 parcels jupyter cartopy ffmpeg
-
-# make parcels AT=<installation directory> ENV=<env_name>
-parcels_examples:
-	conda activate $$ENV
-	parcels_get_examples $$AT/parcels_examples

--- a/Python/utils/Makefile
+++ b/Python/utils/Makefile
@@ -41,3 +41,13 @@ dedalus:
 	yes | conda install -n dedalus -c conda-forge seawater
 	yes | conda install -n dedalus -c conda-forge pandas
 	yes | conda install -n dedalus -c conda-forge seaborn
+
+# make parcels ENV=<env_name>
+parcels:
+	conda activate root
+	yes | conda create -n $$ENV -c conda-forge python=3.6 parcels jupyter cartopy ffmpeg
+
+# make parcels AT=<installation directory> ENV=<env_name>
+parcels_examples:
+	conda activate $$ENV
+	parcels_get_examples $$AT/parcels_examples


### PR DESCRIPTION
Please, check if the new option "make parcels ENV=py3_parcels" work. It's supposed to install the Ocean Parcels python package and dependencies in a new environment.